### PR TITLE
chore: ignore build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/src/main/main


### PR DESCRIPTION
introduces .gitignore and adds the *nix build artifact `src/main/main` to it