### PR TITLE
fix: use full import path for mud core package

### DIFF
--- a/src/main/main.go
+++ b/src/main/main.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"saevenx"
+
+	mudcore "github.com/Saeven/golang-mud/src/saevenx"
 )
 
 func main() {
@@ -17,7 +18,7 @@ func main() {
 	checkError(err)
 	defer listener.Close()
 
-	saevenx.GetServer().Start()
+	mudcore.GetServer().Start()
 	listenForConnections(listener)
 }
 
@@ -39,5 +40,5 @@ func checkError(err error) {
 }
 
 func newDescriptor(connection net.Conn) {
-	saevenx.ServerInstance.AddConnection(connection)
+	mudcore.ServerInstance.AddConnection(connection)
 }


### PR DESCRIPTION
Not sure if there was a way this built in the past but I couldn't get it to work, I've never seen a relative import path in golang before. So this changes the `saevenx` package reference to a full path so main can build with just `go build`